### PR TITLE
save username to wager.manager field when loading wagers

### DIFF
--- a/client/src/EventTable.js
+++ b/client/src/EventTable.js
@@ -30,7 +30,10 @@ module.exports = React.createClass({
     const authorsToSave = this.state.eventAuthors.filter(a => a.author != null)
     http
       .post(baseUrl + '/surprise/wager/authors', JSON.stringify(authorsToSave))
-      .then(r => console.log(r.status))
+      .then(r => {
+        console.log(r.status)
+        this.props.reload()
+      })
   },
   render: function() {
     const eventRows = this.props.events.map((e, i) =>

--- a/client/src/Surprise.js
+++ b/client/src/Surprise.js
@@ -53,7 +53,7 @@ module.exports = React.createClass({
                 <WagerTable wagers = {this.state.wagers} handleClick = {this.handleRowClick} selected = {this.state.selected}/>
                 </div>
                 <div className="col-md-6">
-                  <EventTable events = {this.getSelectedEvents()} availableAuthors = {this.state.availableAuthors}/>
+                  <EventTable events = {this.getSelectedEvents()} availableAuthors = {this.state.availableAuthors} reload={this.reloadData} />
                 </div>
               </div>
             </div>

--- a/client/src/WagerRow.js
+++ b/client/src/WagerRow.js
@@ -12,6 +12,7 @@ module.exports = React.createClass ({
         <td>{this.props.system}</td>
         <td>{this.props.hits}</td>
         <td>{this.props.win_amount}</td>
+        <td>{this.props.manager}</td>
       </tr>)
   }
 })

--- a/client/src/WagerTable.js
+++ b/client/src/WagerTable.js
@@ -14,6 +14,7 @@ module.exports = React.createClass ({
       system={w.system}
       hits={w.hits}
       win_amount={w.win_amount}
+      manager={w.manager}
       index={i}
       key={i}
       />
@@ -27,6 +28,7 @@ module.exports = React.createClass ({
               <th>System</th>
               <th>Hits</th>
               <th>Winning</th>
+              <th>Manager</th>
             </tr>
           </thead>
           <tbody>{wagerRows}</tbody>

--- a/server/wagerserver.py
+++ b/server/wagerserver.py
@@ -45,6 +45,7 @@ def load_wagers():
     wagers = wc.get_wagers(s)
     saved = 0
     for w in wagers:
+        w.manager = credentials['username']
         if db.save_wager(w) > 0:
             saved += 1
     message_json = json.dumps({'loadedWagers' : str(len(wagers)), 'savedWagers': str(saved)}, indent=4)


### PR DESCRIPTION
part 1: (this commit)
- save Veikkaus username to wager.manager field when loading wagers
- because of "foreign key (manager)", this username should be in user.username field

part 2:
- render wager.manager value in wager table on UI
- also, we could add new field into user -table (eg. name) that displays the nickname (eg. Carlitos). Then this nickname could be linked with username when rendering on UI 